### PR TITLE
Modify footer to include ref to Eclipse foundation trademark policy

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -8,6 +8,12 @@ module.exports = function (eleventyConfig) {
     return markdownIt.render(content || "");
   });
 
+  // Add inline markdown filter (no paragraph wrapping)
+  eleventyConfig.addFilter("markdownInline", function (content) {
+    const markdownIt = require("markdown-it")();
+    return markdownIt.renderInline(content || "");
+  });
+
   // Add category title filter
   eleventyConfig.addFilter("categoryTitle", function (category) {
     return category

--- a/src/_data/site.json
+++ b/src/_data/site.json
@@ -11,39 +11,21 @@
         "content": "This website does not collect any personal information beyond what is [collected by GitHub Pages](https://docs.github.com/en/pages/getting-started-with-github-pages/what-is-github-pages#data-collection) for hosting purposes."
       },
       {
-        "title": "Licenses",
-        "content": "Copyright ORC WG Contributors.",
-        "links": [
-          {
-            "text": "Content (CC-By 4.0)",
-            "url": "https://github.com/orcwg/cra-hub/blob/main/LICENSE.md"
-          },
-          {
-            "text": "Source code (Apache License 2.0)",
-            "url": "https://github.com/orcwg/cra.orcwg.org/blob/main/LICENSE"
-          }
+        "title": "Licenses & Trademarks",
+        "list": [
+          "Copyright [ORC WG Contributors](https://github.com/orcwg/cra-hub/graphs/contributors).",
+          "Content: [CC-By 4.0](https://github.com/orcwg/cra-hub/blob/main/LICENSE.md).",
+          "Source code: [Apache License 2.0](https://github.com/orcwg/cra.orcwg.org/blob/main/LICENSE).",
+          "ORC WG logo and Orc Mascot are trademarks of the Eclipse Foundation (see [policy](https://www.eclipse.org/legal/logo-guidelines/))."
         ]
-        
       },
       {
         "title": "Community Resources",
-        "links": [
-          {
-            "text": "CRA FAQ GitHub Repository",
-            "url": "https://github.com/orcwg/cra-hub/"
-          },
-          {
-            "text": "FAQ Task Force",
-            "url": "https://github.com/orcwg/cyber-resilience-sig/tree/main/task-forces/faq-tf"
-          },
-          {
-            "text": "Source code of this website",
-            "url": "https://github.com/orcwg/cra.orcwg.org/"
-          },
-          {
-            "text": "Open Regulatory Compliance Working Group",
-            "url": "https://orcwg.org"
-          }
+        "list": [
+          "[CRA FAQ GitHub Repository](https://github.com/orcwg/cra-hub/)",
+          "[FAQ Task Force](https://github.com/orcwg/cyber-resilience-sig/tree/main/task-forces/faq-tf)",
+          "[Website source code](https://github.com/orcwg/cra.orcwg.org/)",
+          "[Open Regulatory Compliance WG](https://orcwg.org)"
         ]
       }
     ]

--- a/src/_includes/footer.njk
+++ b/src/_includes/footer.njk
@@ -6,10 +6,10 @@
             {% if section.content %}
                 <p>{{ section.content | markdown | safe }}</p>
             {% endif %}
-            {% if section.links %}
+            {% if section.list %}
                 <ul>
-                {% for link in section.links %}
-                    <li><a href="{{ link.url }}" target="_blank" rel="noopener">{{ link.text }}</a></li>
+                {% for item in section.list %}
+                    <li>{{ item | markdownInline | safe }}</li>
                 {% endfor %}
                 </ul>
             {% endif %}


### PR DESCRIPTION
Looks like this:

<img width="932" height="215" alt="Screenshot 2025-10-06 at 21 49 35" src="https://github.com/user-attachments/assets/84711167-a798-46c7-a9b2-dbdae0a733fb" />
