### PR TITLE
add  "safe" filter to avoid nunjuck HTML auto-escaping

### DIFF
--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ site.title }}{% if title %} - {{ title | striptags }}{% endif %}</title>
+    <title>{{ site.title }}{% if title %} - {{ title | striptags | safe }}{% endif %}</title>
 
     <link rel="icon" href="/assets/images/favicon.ico" sizes="32x32">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/images/favicon-16x16.png">


### PR DESCRIPTION
## Problem
Related to #56

FAQ titles containing HTML entities are being escaped and displayed as raw text.

**Example:**
- Current: `CRA FAQ - What does &quot;Monetizing without making a profit&quot; mean?` → displays as `CRA FAQ - What does &quot;Monetizing without making a profit&quot; mean?`
- Expected: `CRA FAQ - What does &quot;Monetizing without making a profit&quot; mean?` → should display as `CRA FAQ - What does "Monetizing without making a profit" mean?`

## Solution
Added the `safe` filter to disable Nunjucks' automatic HTML escaping for FAQ titles in `src\_includes\layout.njk`.