### PR TITLE
Support for footnotes in FAQ questions.

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -4,8 +4,12 @@ module.exports = async function (eleventyConfig) {
 
   // Import ES modules dynamically
   const markdownIt = require("markdown-it");
+  
   const { default: markdownItGitHubAlerts } = await import("markdown-it-github-alerts");
-
+  
+  // Footnote plugin for markdown-it
+  const markdownItFootnote = require("markdown-it-footnote");
+  
   // Plugin to add internal links to markdown-it's reference system
   function markdownItInternalLinks(md) {
     // Preprocessing rule to convert [[Article X]] syntax to markdown links
@@ -129,7 +133,7 @@ module.exports = async function (eleventyConfig) {
     html: true,
     linkify: true,
     typographer: true
-  }).use(markdownItGitHubAlerts).use(markdownItInternalLinks);
+  }).use(markdownItGitHubAlerts).use(markdownItInternalLinks).use(markdownItFootnote);
 
   // Add markdown filter
   eleventyConfig.addFilter("markdown", function (content, context = null) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "js-yaml": "^4.1.0",
         "markdown-it": "^14.1.0",
+        "markdown-it-footnote": "^4.0.0",
         "markdown-it-github-alerts": "^1.0.0",
         "markdown-it-plain-text": "^0.3.0"
       },
@@ -1133,6 +1134,7 @@
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
       "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
@@ -1144,6 +1146,12 @@
       "bin": {
         "markdown-it": "bin/markdown-it.mjs"
       }
+    },
+    "node_modules/markdown-it-footnote": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-footnote/-/markdown-it-footnote-4.0.0.tgz",
+      "integrity": "sha512-WYJ7urf+khJYl3DqofQpYfEYkZKbmXmwxQV8c8mO/hGIhgZ1wOe7R4HLFNwqx7TjILbnC98fuyeSsin19JdFcQ==",
+      "license": "MIT"
     },
     "node_modules/markdown-it-github-alerts": {
       "version": "1.0.0",
@@ -1381,6 +1389,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1404,6 +1413,7 @@
       "integrity": "sha512-JcEmHlyLK/o0uGAlj65vgg+7LIms0xKXe60lcDOTU7oVX/3LuEuLwrQpW3VJ7de5TaFKiW4kWkaIpJL42FEgxQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "posthtml-parser": "^0.11.0",
         "posthtml-render": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "js-yaml": "^4.1.0",
     "markdown-it": "^14.1.0",
+    "markdown-it-footnote": "^4.0.0",
     "markdown-it-github-alerts": "^1.0.0",
     "markdown-it-plain-text": "^0.3.0"
   }


### PR DESCRIPTION
Closes #122

This PR adds the markdown-it-footnote plugin to the Markdown pipeline. It enables rendering of footnotes (e.g., [^1]) in .md documents.

Changes: 
- Installed markdown-it-footnote dependency.
- Updated Eleventy Markdown configuration to register the plugin.

Previous: 
<img width="852" height="396" alt="image" src="https://github.com/user-attachments/assets/cdec3f0b-0e85-42e1-8a57-5a066a79a9de" />

Updated:
<img width="1053" height="551" alt="image" src="https://github.com/user-attachments/assets/9415aeeb-f173-4ac2-b4e7-987286181a86" />



