### PR TITLE
Fix: Use correct variable reference for edit URL

### DIFF
--- a/src/guidance.njk
+++ b/src/guidance.njk
@@ -29,7 +29,7 @@ eleventyComputed:
   </div>
 
   <div class="regular-actions">
-    <a href="{{ guidance.editOnGithubUrl }}" class="action-button" target="_blank" rel="noopener" title="Edit this guidance on GitHub">
+    <a href="{{ item.editOnGithubUrl }}" class="action-button" target="_blank" rel="noopener" title="Edit this guidance on GitHub">
       {% include "icons/edit.svg" %}
       <span>Edit on GitHub</span>
     </a>


### PR DESCRIPTION
Sorry about that! Changed `guidance.editOnGithubUrl` to `item.editOnGithubUrl` to match the pagination context. Button now links correctly to GitHub.
@ninnlangel 