### PR TITLE
add a link to the ORC Brand Guideline just after the section Intro

### DIFF
--- a/src/style-guide.njk
+++ b/src/style-guide.njk
@@ -10,15 +10,6 @@ eleventyExcludeFromCollections: true
   <p>Edit <code>_data/style-guide-content.md</code> or <code>_data/styleGuideData.js</code> to update examples.</p>
 </section>
 
-<aside class="info">
-<h2>ORC WG Brand Guidelines</h2>
-<article class="section-card">
-  <p>For the official ORC Working Group logo and brand usage guidelines, check the <a href="https://www.eclipse.org/org/artwork/guidelines/orc-branding-guidelines.pdf">ORC Brand Guidelines (PDF)</a> provided by the Eclipse Foundation</p>
-</article>
-</aside>
-
-
-
 <h2>Markdown Content Examples</h2>
 
 <article class="section-card">
@@ -162,4 +153,9 @@ eleventyExcludeFromCollections: true
     <li>Native <code>&lt;details&gt;</code> with <code>name</code> attribute for exclusive accordions</li>
     <li>Minimal JavaScript - only for badge visibility toggles</li>
   </ul>
+</section>
+
+<h2>ORC WG Brand Guidelines</h2>
+<section class="section-card">
+  <p>For the official ORC Working Group logo and brand usage guidelines, check the <a href="https://www.eclipse.org/org/artwork/guidelines/orc-branding-guidelines.pdf">ORC Brand Guidelines (PDF)</a> provided by the Eclipse Foundation</p>
 </section>


### PR DESCRIPTION
- Add a h2 just after the section-intro with a <aside "info"> to make the link pop up

closes #124 

<img width="1228" height="308" alt="image" src="https://github.com/user-attachments/assets/c143143e-c894-4b61-a4a2-3ecfcc0a1353" />
