### PR TITLE
Fix broken relative link processing and add reference-style link support

### DIFF
--- a/src/_data/data.js
+++ b/src/_data/data.js
@@ -207,7 +207,7 @@ function getMarkdownFile(entry) {
   const posixPathWithoutExt = file.posixPath.replace(/\.md$/, "");
   file.permalink = "/" + posixPathWithoutExt + "/"; // backslash to make eleventy happy
   file.id = posixPathWithoutExt.replace(/^faq\//, "");
-  file.category = file.id.replace(/\/[^\/]$/, "");
+  file.category = file.id.replace(/\/[^\/]+$/, ""); // Extract directory path (everything before last slash)
   return file;
 }
 


### PR DESCRIPTION
This commit fixes link resolution issues that occurred when the link resolver was moved to a module (commit 855a051).

Changes to src/_data/data.js:
- Fixed category extraction regex from /\/[^\/]$/ to /\/[^\/]+$/
- Old regex only matched last 2 chars, causing incorrect categories
- Now correctly extracts directory path (everything before last slash)

Changes to src/_data/utils/link-resolver.js:
- Added support for reference-style markdown links ([label][])
- Expanded file type support (removed .md/.yml restriction in patterns)
- Added global flag to inline relative link processing
- Implemented two-phase reference link resolution:
  1. Collect definitions and resolve paths
  2. Replace usages with inline links including tooltips
- Added concise comments explaining regex patterns and logic flow

Fixes:
- Reference-style links like [CE mark][] now resolve correctly
- Multiple relative links on same line now all get processed
- Category paths are now extracted correctly for nested FAQs