### PR TITLE
Add header and footer from orcwg.org

### DIFF
--- a/src/_data/site.json
+++ b/src/_data/site.json
@@ -3,62 +3,65 @@
   "navigation": {
     "main": [
       {
+        "id": "about",
         "title": "About",
         "url": null,
         "description": "About the organization",
         "children": [
           {
             "title": "ORC Working Group",
-            "url": "/about/",
+            "url": "https://orcwg.org/about/",
             "description": "Learn about the ORC Working Group"
           },
           {
             "title": "Cyber Resilience SIG",
-            "url": "/special-interest-groups/cyber-resilience/",
+            "url": "https://orcwg.org/special-interest-groups/cyber-resilience/",
             "description": "Explore the Cyber Resilience Special Interest Group"
           }
         ]
       },
       {
+        "id": "membership",
         "title": "Membership",
         "url": null,
         "description": "Membership information",
         "children": [
           {
             "title": "Our Members",
-            "url": "/membership/",
+            "url": "https://orcwg.org/membership/",
             "description": "See the list of members"
           },
           {
             "title": "Become a Member",
-            "url": "/membership/become-a-member/",
+            "url": "https://orcwg.org/membership/become-a-member/",
             "description": "Information on joining the group"
           },
           {
             "title": "Participation and Membership FAQ",
-            "url": "/about/participation-and-membership-faq/",
+            "url": "https://orcwg.org/about/participation-and-membership-faq/",
             "description": "FAQs on participation and membership"
           }
         ]
       },
       {
+        "id": "cra",
         "title": "Cyber Resilience Act",
-        "url": "/cra/",
+        "url": "https://orcwg.org/cra/",
         "description": "Overview of the Cyber Resilience Act",
         "children": [
           {
             "title": "About CRA",
-            "url": "/cra/about",
+            "url": "https://orcwg.org/cra/about",
             "description": "Information about the CRA"
           },
           {
             "title": "CRA FAQ",
-            "url": "https://cra.orcwg.org/",
+            "url": "",
             "description": "Frequently Asked Questions on CRA"
           },
           {
             "title": "CRA Resources",
-            "url": "/cra/resources",
+            "url": "https://orcwg.org/cra/resources",
             "description": "Resources related to the CRA"
           },
           {
@@ -69,33 +72,34 @@
         ]
       },
       {
+        "id": "resources",
         "title": "Resources",
         "url": null,
         "description": "General resources",
         "children": [
           {
             "title": "Events",
-            "url": "/events/",
+            "url": "https://orcwg.org/events/",
             "description": "Upcoming events"
           },
           {
             "title": "Community Calendar",
-            "url": "/resources/calendar/",
+            "url": "https://orcwg.org/resources/calendar/",
             "description": "Check the community calendar"
           },
           {
             "title": "Blog",
-            "url": "/blog/",
+            "url": "https://orcwg.org/blog/",
             "description": "Latest posts from the ORC community"
           },
           {
             "title": "Videos",
-            "url": "/resources/videos/",
+            "url": "https://orcwg.org/resources/videos/",
             "description": "Video resources"
           },
           {
             "title": "Marketing Resources",
-            "url": "/resources/marketing-resources/",
+            "url": "https://orcwg.org/resources/marketing-resources/",
             "description": "Marketing and promotional materials"
           },
           {
@@ -126,36 +130,6 @@
         "url": "/pending-guidance/",
         "title": "Pending Guidance",
         "description": "Topics requiring additional clarification by the European Commission"
-      }
-    ]
-  },
-  "footer": {
-    "sections": [
-      {
-        "title": "About",
-        "content": "The CRA Hub is a community resource of the [Open Regulatory Compliance (ORC) Working Group](https://orcwg.org). It is built by [UnlockOpen](https://unlockopen.com) with direct funding from the [Eclipse Foundation](https://eclipse.org)."
-      },
-      {
-        "title": "Privacy",
-        "content": "This website does not collect any personal information beyond what is [collected by GitHub Pages](https://docs.github.com/en/pages/getting-started-with-github-pages/what-is-github-pages#data-collection) for hosting purposes and [Fathom Analytics](https://usefathom.com/legal/compliance) for privacy-first [website analytics](https://app.usefathom.com/share/fwabmjvu/cra.orcwg.org)."
-      },
-      {
-        "title": "Licenses & Trademarks",
-        "list": [
-          "Source code: [Apache License 2.0](https://github.com/orcwg/cra.orcwg.org/blob/main/LICENSE).",
-          "ORC WG logo and Orc Mascot are trademarks of the Eclipse Foundation (see [policy](https://www.eclipse.org/legal/logo-guidelines/))."
-        ]
-      },
-      {
-        "title": "Community Resources",
-        "list": [
-          "[CRA FAQ GitHub Repository](https://github.com/orcwg/cra-hub/)",
-          "[FAQ Task Force](https://github.com/orcwg/orcwg/tree/main/cyber-resilience-sig/task-forces/faq-tf)",
-          "[Website source code](https://github.com/orcwg/cra.orcwg.org/)",
-          "[Website Style Guide](/style-guide/)",
-          "[Open Regulatory Compliance WG](https://orcwg.org)",
-          "[Acknowledgements](/acknowledgements/)"
-        ]
       }
     ]
   }

--- a/src/_data/site.json
+++ b/src/_data/site.json
@@ -1,27 +1,134 @@
 {
   "title": "CRA FAQ",
-  "navigation": [
-    {
-      "url": "/faq/all/",
-      "title": "All FAQs",
-      "description": "Browse all FAQs in one single list"
-    },
-    {
-      "url": "/faq/official/",
-      "title": "🇪🇺 Official FAQs",
-      "description": "Browse the official FAQs of the EU Commission"
-    },
-    {
-      "url": "/faq/",
-      "title": "Topics",
-      "description": "FAQs organized by topic and/or audience"
-    },
-    {
-      "url": "/pending-guidance/",
-      "title": "Pending Guidance",
-      "description": "Topics requiring additional clarification by the European Commission"
-    }
-  ],
+  "navigation": {
+    "main": [
+      {
+        "title": "About",
+        "url": null,
+        "description": "About the organization",
+        "children": [
+          {
+            "title": "ORC Working Group",
+            "url": "/about/",
+            "description": "Learn about the ORC Working Group"
+          },
+          {
+            "title": "Cyber Resilience SIG",
+            "url": "/special-interest-groups/cyber-resilience/",
+            "description": "Explore the Cyber Resilience Special Interest Group"
+          }
+        ]
+      },
+      {
+        "title": "Membership",
+        "url": null,
+        "description": "Membership information",
+        "children": [
+          {
+            "title": "Our Members",
+            "url": "/membership/",
+            "description": "See the list of members"
+          },
+          {
+            "title": "Become a Member",
+            "url": "/membership/become-a-member/",
+            "description": "Information on joining the group"
+          },
+          {
+            "title": "Participation and Membership FAQ",
+            "url": "/about/participation-and-membership-faq/",
+            "description": "FAQs on participation and membership"
+          }
+        ]
+      },
+      {
+        "title": "Cyber Resilience Act",
+        "url": "/cra/",
+        "description": "Overview of the Cyber Resilience Act",
+        "children": [
+          {
+            "title": "About CRA",
+            "url": "/cra/about",
+            "description": "Information about the CRA"
+          },
+          {
+            "title": "CRA FAQ",
+            "url": "https://cra.orcwg.org/",
+            "description": "Frequently Asked Questions on CRA"
+          },
+          {
+            "title": "CRA Resources",
+            "url": "/cra/resources",
+            "description": "Resources related to the CRA"
+          },
+          {
+            "title": "CRA Hub on GitHub",
+            "url": "https://github.com/orcwg/cra-hub",
+            "description": "CRA Hub source and resources on GitHub"
+          }
+        ]
+      },
+      {
+        "title": "Resources",
+        "url": null,
+        "description": "General resources",
+        "children": [
+          {
+            "title": "Events",
+            "url": "/events/",
+            "description": "Upcoming events"
+          },
+          {
+            "title": "Community Calendar",
+            "url": "/resources/calendar/",
+            "description": "Check the community calendar"
+          },
+          {
+            "title": "Blog",
+            "url": "/blog/",
+            "description": "Latest posts from the ORC community"
+          },
+          {
+            "title": "Videos",
+            "url": "/resources/videos/",
+            "description": "Video resources"
+          },
+          {
+            "title": "Marketing Resources",
+            "url": "/resources/marketing-resources/",
+            "description": "Marketing and promotional materials"
+          },
+          {
+            "title": "ORC Store",
+            "url": "https://eclipse-foundation.store/collections/open-regulatory-compliance-orc",
+            "description": "Shop ORC-related materials and resources"
+          }
+        ]
+      }
+    ],
+    "sub": [
+      {
+        "url": "/faq/all/",
+        "title": "All FAQs",
+        "description": "Browse all FAQs in one single list"
+      },
+      {
+        "url": "/faq/official/",
+        "title": "🇪🇺 Official FAQs",
+        "description": "Browse the official FAQs of the EU Commission"
+      },
+      {
+        "url": "/faq/",
+        "title": "Topics",
+        "description": "FAQs organized by topic and/or audience"
+      },
+      {
+        "url": "/pending-guidance/",
+        "title": "Pending Guidance",
+        "description": "Topics requiring additional clarification by the European Commission"
+      }
+    ]
+  },
   "footer": {
     "sections": [
       {

--- a/src/_includes/footer.njk
+++ b/src/_includes/footer.njk
@@ -1,30 +1,90 @@
-<footer>
-    {% for section in site.footer.sections %}
-    <section>
-        <h4>{{ section.title }}</h4>
-        {% if section.content %}
-            {{ section.content | markdown | safe }}
-        {% endif %}
-        {% if section.title == "About" %}
-            <p>Website last updated on <time datetime="{{ build.iso }}">{{ build.formatted }}</time>.</p>
-        {% endif %}
-        {% if section.list %}
-            <ul>
-            {% for item in section.list %}
-                <li>{{ item | markdownInline | safe }}</li>
-            {% endfor %}
-            {% if section.title == "Community Resources" %}
-                <li>
-                    <button class="admin-toggle" title="Toggle admin mode" aria-label="Toggle admin mode">
-                        Admin info
-                        <span class="toggle-switch">
-                            <span class="toggle-slider"></span>
-                        </span>
-                    </button>
-                </li>
-            {% endif %}
-            </ul>
-        {% endif %}
-    </section>
-    {% endfor %}
+<footer class="footer footer-working-group" id="footer">
+    <div class="container">
+        <div class="footer-end-social-container margin-bottom-30">
+            <div class="footer-end-social">
+                <p class="footer-end-social-text hidden-xs">Follow Us:</p>
+                <ul class="footer-end-social-links list-unstyled">
+                    <li><a class="link-unstyled" href="https://www.linkedin.com/showcase/open-regulatory-compliance/" title="LinkedIn account"><span class="fa-stack"><i class="fa-solid fa-circle fa-stack-2x" aria-hidden="true"></i>
+                        <i class="fa-brands fa-linkedin-in fa-stack-1x fa-inverse" aria-hidden="true"></i>
+                        <span class="sr-only">LinkedIn account</span></span></a>
+                    </li>
+                    <li><a class="link-unstyled" href="https://youtube.com/playlist?list=PLy7t4z5SYNaQEyXv253SI6PDdPjbYXcNV&amp;si=wLNnW7iG3ruKSEvb" title="YouTube account"><span class="fa-stack"><i class="fa-solid fa-circle fa-stack-2x" aria-hidden="true"></i>
+                        <i class="fa-brands fa-youtube fa-stack-1x fa-inverse" aria-hidden="true"></i>
+                        <span class="sr-only">YouTube account</span></span></a>
+                    </li>
+                    <li><a class="link-unstyled" href="https://bsky.app/profile/orcwg.org" title="Bluesky account"><span class="fa-stack"><i class="fa-solid fa-circle fa-stack-2x" aria-hidden="true"></i>
+                        <i class="fa-brands fa-bluesky fa-stack-1x fa-inverse" aria-hidden="true"></i>
+                        <span class="sr-only">Bluesky account</span></span></a>
+                    </li>
+                    <li><a class="link-unstyled" href="https://fosstodon.org/@orcwg" title="Mastodon account"><span class="fa-stack"><i class="fa-solid fa-circle fa-stack-2x" aria-hidden="true"></i>
+                        <i class="fa-brands fa-mastodon fa-stack-1x fa-inverse" aria-hidden="true"></i>
+                        <span class="sr-only">Mastodon account</span></span></a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+        <div class="text-center margin-bottom-40">
+            <img class="img-responsive margin-x-auto margin-bottom-30" src="https://www.eclipse.org/eclipse.org-common/themes/solstice/public/images/logo/eclipse-foundation-grey-orange.svg" width="150" aria-labelledby="footer-working-group-ef">
+            <div class="footer-working-group-sponsor">
+                <div class="footer-working-group-circle-group">
+                    <div class="footer-working-group-circle"></div>
+                    <div class="footer-working-group-circle"></div>
+                    <div class="footer-working-group-circle hidden-xs"></div>
+                    <div class="footer-working-group-circle hidden-xs"></div>
+                </div>
+                <p class="fw-500" id="footer-working-group-ef">An Eclipse Foundation Working Group</p>
+                <div class="footer-working-group-circle-group">
+                    <div class="footer-working-group-circle"></div>
+                    <div class="footer-working-group-circle hidden-xs"></div>
+                    <div class="footer-working-group-circle hidden-xs"></div>
+                    <div class="footer-working-group-circle"></div>
+                </div>
+            </div>
+        </div>
+        <div class="footer-sections row equal-height-md font-bold">
+            <div class="col-sm-20 col-sm-offset-4 col-xs-24">
+                <section id="footer-eclipse-foundation" class="footer-section col-sm-8">
+                    <div class="menu-heading">Eclipse Foundation</div>
+                    <ul class="nav">
+                        <li><a href="https://www.eclipse.org/org/">About</a></li>
+                        <li><a href="https://projects.eclipse.org/">Projects</a></li>
+                        <li><a href="https://www.eclipse.org/collaborations/">Collaborations</a></li>
+                        <li><a href="https://www.eclipse.org/membership/">Membership</a></li>
+                        <li><a href="https://www.eclipse.org/sponsor/">Sponsor</a></li>
+                    </ul>
+                </section>
+                <section id="footer-legal" class="footer-section col-sm-8">
+                    <div class="menu-heading">Legal</div>
+                    <ul class="nav">
+                        <li><a href="https://www.eclipse.org/legal/privacy/">Privacy Policy</a></li>
+                        <li><a href="https://www.eclipse.org/legal/terms-of-use/">Terms of Use</a></li>
+                        <li><a href="https://www.eclipse.org/legal/compliance/">Compliance</a></li>
+                        <li><a href="https://www.eclipse.org/org/documents/Community_Code_of_Conduct.php">Code of Conduct</a></li>
+                        <li><a href="https://www.eclipse.org/legal/">Legal Resources</a></li>
+                        <li><a class="toolbar-manage-cookies" href="#" onclick="event.preventDefault()">Manage Cookies</a></li>
+                    </ul>
+                </section>
+                <section id="footer-more" class="footer-section col-sm-8">
+                    <div class="menu-heading">More</div>
+                    <ul class="nav">
+                        <li><a href="https://www.eclipse.org/security/">Report a Vulnerability</a></li>
+                        <li><a href="https://status.eclipse.org/">Service Status</a></li>
+                        <li><a href="https://www.eclipse.org/org/foundation/contact.php">Contact Us</a></li>
+                        <li><a href="https://www.eclipse.org/projects/support/">Support</a></li>
+                    </ul>
+                </section>
+            </div>
+            <div id="footer-end" class="footer-section col-md-8 col-md-offset-1 col-sm-24"></div>
+        </div>
+        <div class="text-center">
+            <div class="col-sm-24 margin-top-20">
+                <div class="row">
+                    <div id="copyright" class="col-sm-16">
+                        <p id="copyright-text">Copyright © Eclipse Foundation AISBL. All Rights Reserved.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <a href="#" class="scrollup" style="display: inline;">Back to the top</a>
+    </div>
 </footer>

--- a/src/_includes/footer.njk
+++ b/src/_includes/footer.njk
@@ -79,7 +79,8 @@
         <div class="text-center">
             <div class="col-sm-24 margin-top-20">
                 <div class="row">
-                    <div id="copyright" class="col-sm-16">
+                    <p class="text-muted"><small>Built by UnlockOpen with direct funding from the Eclipse Foundation.</small></p>
+                    <div id="copyright">
                         <p id="copyright-text">Copyright © Eclipse Foundation AISBL. All Rights Reserved.</p>
                     </div>
                 </div>

--- a/src/_includes/header.njk
+++ b/src/_includes/header.njk
@@ -2,14 +2,14 @@
     <div class="header-navbar-wrapper">
         <div class="container">
             <div class="header-navbar">
-                <div class="header-navbar-brand"><a class="logo-wrapper" href="/" title="Open Regulatory Compliance Working Group"><img src="https://orcwg.org/images/orc-logo.png" alt="" width="120"></a></div>
+                <div class="header-navbar-brand"><a class="logo-wrapper" href="https://orcwg.org" title="Open Regulatory Compliance Working Group"><img src="https://orcwg.org/images/orc-logo.png" alt="" width="120"></a></div>
                 <nav class="header-navbar-nav">
                     <ul class="header-navbar-nav-links">
                         {% for nav in site.navigation.main %} 
                         <li class="navbar-nav-links-item">
                         {% if nav.children %}
                             <div class="dropdown">
-                                <button class="btn-link link-unstyled" id="cra" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                <button class="btn-link link-unstyled" id="{{ nav.id }}" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                     {{ nav.title }}
                                     <i class="fa fa-caret-down" aria-hidden="true"></i>
                                 </button>
@@ -36,147 +36,32 @@
     </div>
     <nav class="mobile-menu hidden" aria-expanded="false">
         <ul>
+            {% for nav in site.navigation.main %}
+            {% if nav.children %}
             <li class="mobile-menu-dropdown">
-                <a class="mobile-menu-item mobile-menu-dropdown-toggle" data-target="about-menu"><span>About</span>
+                <a class="mobile-menu-item mobile-menu-dropdown-toggle" data-target="{{ nav.id }}-menu"><span>{{ nav.title }}</span>
                 <i class="fa fa-chevron-down" aria-hidden="true"></i></a>
                 <div class="mobile-menu-sub-menu-wrapper">
-                    <ul class="mobile-menu-sub-menu mobile-menu-links-menu hidden" id="about-menu">
-                        <li><a class="mobile-menu-item" href="https://orcwg.org/about/">ORC Working Group</a></li>
-                        <li><a class="mobile-menu-item" href="https://orcwg.org/special-interest-groups/cyber-resilience/">Cyber Resilience SIG</a></li>
+                    <ul class="mobile-menu-sub-menu mobile-menu-links-menu hidden" id="{{ nav.id }}-menu">
+                        {% for child in nav.children %}
+                            <li><a class="mobile-menu-item" href="{{ child.url }}">{{ child.title }}</a></li>
+                        {% endfor %}
                     </ul>
                 </div>
             </li>
-            <li class="mobile-menu-dropdown">
-                <a class="mobile-menu-item mobile-menu-dropdown-toggle" data-target="membership-menu"><span>Membership</span>
-                <i class="fa fa-chevron-down" aria-hidden="true"></i></a>
-                <div class="mobile-menu-sub-menu-wrapper">
-                    <ul class="mobile-menu-sub-menu mobile-menu-links-menu hidden" id="membership-menu">
-                        <li><a class="mobile-menu-item" href="https://orcwg.org/membership/">Our Members</a></li>
-                        <li><a class="mobile-menu-item" href="https://orcwg.org/membership/become-a-member/">Become a Member</a></li>
-                        <li><a class="mobile-menu-item" href="https://orcwg.org/about/participation-and-membership-faq/">Participation and Membership FAQ</a></li>
-                    </ul>
-                </div>
-            </li>
-            <li class="mobile-menu-dropdown">
-                <a class="mobile-menu-item mobile-menu-dropdown-toggle" data-target="cra-menu"><span>Cyber Resilience Act</span>
-                <i class="fa fa-chevron-down" aria-hidden="true"></i></a>
-                <div class="mobile-menu-sub-menu-wrapper">
-                    <ul class="mobile-menu-sub-menu mobile-menu-links-menu hidden" id="cra-menu">
-                        <li><a class="mobile-menu-item" href="https://orcwg.org/cra/about">About CRA</a></li>
-                        <li><a class="mobile-menu-item" href="/">CRA FAQ</a></li>
-                        <li><a class="mobile-menu-item" href="https://orcwg.org/cra/resources">CRA Resources</a></li>
-                        <li><a class="mobile-menu-item" href="https://github.com/orcwg/cra-hub">CRA Hub on GitHub</a></li>
-                    </ul>
-                </div>
-            </li>
-            <li class="mobile-menu-dropdown">
-                <a class="mobile-menu-item mobile-menu-dropdown-toggle" data-target="resources-menu"><span>Resources</span>
-                <i class="fa fa-chevron-down" aria-hidden="true"></i></a>
-                <div class="mobile-menu-sub-menu-wrapper">
-                    <ul class="mobile-menu-sub-menu mobile-menu-links-menu hidden" id="resources-menu">
-                        <li><a class="mobile-menu-item" href="https://orcwg.org/events/">Events</a></li>
-                        <li><a class="mobile-menu-item" href="https://orcwg.org/resources/calendar/">Community Calendar</a></li>
-                        <li><a class="mobile-menu-item" href="https://orcwg.org/blog/">Blog</a></li>
-                        <li><a class="mobile-menu-item" href="https://orcwg.org/resources/videos/">Videos</a></li>
-                        <li><a class="mobile-menu-item" href="https://orcwg.org/resources/marketing-resources/">Marketing Resources</a></li>
-                        <li><a class="mobile-menu-item" href="https://eclipse-foundation.store/collections/open-regulatory-compliance-orc">ORC Store</a></li>
-                    </ul>
-                </div>
-            </li>
+            {% else %}
+            <li><a class="mobile-menu-item" href="{{ nav.url }}">{{ child.title }}</a></li>
+            {% endif %}
+            {% endfor %}
         </ul>
     </nav>
-    <div class="eclipsefdn-mega-menu">
-        <div class="mega-menu-submenu container hidden" data-menu-id="about-menu">
-            <div class="mega-menu-submenu-featured-story"></div>
-            <div class="mega-menu-submenu-links-section">
-                <div class="mega-menu-submenu-links">
-                    <p class="menu-heading">ORC Working Group</p>
-                    <ul></ul>
-                </div>
-                <div class="mega-menu-submenu-links">
-                    <p class="menu-heading">Cyber Resilience SIG</p>
-                    <ul></ul>
-                </div>
-            </div>
-            <div class="mega-menu-submenu-ad-wrapper">
-                <div class="eclipsefdn-mega-menu-promo-content mega-menu-promo-content" data-ad-format="ads_square" data-ad-publish-to="eclipse_org_home"></div>
-            </div>
-        </div>
-        <div class="mega-menu-submenu container hidden" data-menu-id="membership-menu">
-            <div class="mega-menu-submenu-featured-story"></div>
-            <div class="mega-menu-submenu-links-section">
-                <div class="mega-menu-submenu-links">
-                    <p class="menu-heading">Our Members</p>
-                    <ul></ul>
-                </div>
-                <div class="mega-menu-submenu-links">
-                    <p class="menu-heading">Become a Member</p>
-                    <ul></ul>
-                </div>
-                <div class="mega-menu-submenu-links">
-                    <p class="menu-heading">Participation and Membership FAQ</p>
-                    <ul></ul>
-                </div>
-            </div>
-            <div class="mega-menu-submenu-ad-wrapper">
-                <div class="eclipsefdn-mega-menu-promo-content mega-menu-promo-content" data-ad-format="ads_square" data-ad-publish-to="eclipse_org_home"></div>
-            </div>
-        </div>
-        <div class="mega-menu-submenu container hidden" data-menu-id="cra-menu">
-            <div class="mega-menu-submenu-featured-story"></div>
-            <div class="mega-menu-submenu-links-section">
-                <div class="mega-menu-submenu-links">
-                    <p class="menu-heading">About CRA</p>
-                    <ul></ul>
-                </div>
-                <div class="mega-menu-submenu-links">
-                    <p class="menu-heading">CRA FAQ</p>
-                    <ul></ul>
-                </div>
-                <div class="mega-menu-submenu-links">
-                    <p class="menu-heading">CRA Resources</p>
-                    <ul></ul>
-                </div>
-                <div class="mega-menu-submenu-links">
-                    <p class="menu-heading">CRA Hub on GitHub</p>
-                    <ul></ul>
-                </div>
-            </div>
-            <div class="mega-menu-submenu-ad-wrapper">
-                <div class="eclipsefdn-mega-menu-promo-content mega-menu-promo-content" data-ad-format="ads_square" data-ad-publish-to="eclipse_org_home"></div>
-            </div>
-        </div>
-        <div class="mega-menu-submenu container hidden" data-menu-id="resources-menu">
-            <div class="mega-menu-submenu-featured-story"></div>
-            <div class="mega-menu-submenu-links-section">
-                <div class="mega-menu-submenu-links">
-                    <p class="menu-heading">Events</p>
-                    <ul></ul>
-                </div>
-                <div class="mega-menu-submenu-links">
-                    <p class="menu-heading">Community Calendar</p>
-                    <ul></ul>
-                </div>
-                <div class="mega-menu-submenu-links">
-                    <p class="menu-heading">Blog</p>
-                    <ul></ul>
-                </div>
-                <div class="mega-menu-submenu-links">
-                    <p class="menu-heading">Videos</p>
-                    <ul></ul>
-                </div>
-                <div class="mega-menu-submenu-links">
-                    <p class="menu-heading">Marketing Resources</p>
-                    <ul></ul>
-                </div>
-                <div class="mega-menu-submenu-links">
-                    <p class="menu-heading">ORC Store</p>
-                    <ul></ul>
-                </div>
-            </div>
-            <div class="mega-menu-submenu-ad-wrapper">
-                <div class="eclipsefdn-mega-menu-promo-content mega-menu-promo-content" data-ad-format="ads_square" data-ad-publish-to="eclipse_org_home"></div>
-            </div>
-        </div>
+    <div class="submenu">
+        <nav class="container">
+            <ul>
+                {% for nav in site.navigation.sub %} 
+                <li><a href="{{nav.url}}">{{ nav.title }}</a></li>
+                {% endfor %}
+            </ul>
+        </nav>
     </div>
 </header>

--- a/src/_includes/header.njk
+++ b/src/_includes/header.njk
@@ -5,57 +5,25 @@
                 <div class="header-navbar-brand"><a class="logo-wrapper" href="/" title="Open Regulatory Compliance Working Group"><img src="https://orcwg.org/images/orc-logo.png" alt="" width="120"></a></div>
                 <nav class="header-navbar-nav">
                     <ul class="header-navbar-nav-links">
+                        {% for nav in site.navigation %} 
                         <li class="navbar-nav-links-item">
-                            <div class="dropdown">
-                                <button class="btn-link link-unstyled" id="about" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                About
-                                <i class="fa fa-caret-down" aria-hidden="true"></i></button>
-                                <ul class="dropdown-menu" aria-labelledby="about">
-                                    <li><a class="link-unstyled" href="https://orcwg.org/about/">ORC Working Group</a></li>
-                                    <li><a class="link-unstyled" href="https://orcwg.org/special-interest-groups/cyber-resilience/">Cyber Resilience SIG</a></li>
-                                </ul>
-                            </div>
-                        </li>
-                        <li class="navbar-nav-links-item">
-                            <div class="dropdown">
-                                <button class="btn-link link-unstyled" id="membership" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                Membership
-                                <i class="fa fa-caret-down" aria-hidden="true"></i></button>
-                                <ul class="dropdown-menu" aria-labelledby="membership">
-                                    <li><a class="link-unstyled" href="https://orcwg.org/membership/">Our Members</a></li>
-                                    <li><a class="link-unstyled" href="https://orcwg.org/membership/become-a-member/">Become a Member</a></li>
-                                    <li><a class="link-unstyled" href="https://orcwg.org/about/participation-and-membership-faq/">Participation and Membership FAQ</a></li>
-                                </ul>
-                            </div>
-                        </li>
-                        <li class="navbar-nav-links-item">
+                        {% if nav.children %}
                             <div class="dropdown">
                                 <button class="btn-link link-unstyled" id="cra" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                Cyber Resilience Act
-                                <i class="fa fa-caret-down" aria-hidden="true"></i></button>
+                                    {{ nav.title }}
+                                    <i class="fa fa-caret-down" aria-hidden="true"></i>
+                                </button>
                                 <ul class="dropdown-menu" aria-labelledby="cra">
-                                    <li><a class="link-unstyled" href="https://orcwg.org/cra/about">About CRA</a></li>
-                                    <li><a class="link-unstyled" href="/">CRA FAQ</a></li>
-                                    <li><a class="link-unstyled" href="https://orcwg.org/cra/resources">CRA Resources</a></li>
-                                    <li><a class="link-unstyled" href="https://github.com/orcwg/cra-hub">CRA Hub on GitHub</a></li>
+                                {% for child in nav.children %}
+                                    <li><a class="link-unstyled" title="{{ child.description }}" href="{{ child.url }}">{{ child.title }}</a></li>
+                                {% endfor %}
                                 </ul>
                             </div>
+                        {% else %}
+                        <li><a class="link-unstyled" title="{{ nav.description }}" href="{{ nav.url }}">{{ nav.title }}</a></li>
+                        {% endif %}
                         </li>
-                        <li class="navbar-nav-links-item">
-                            <div class="dropdown">
-                                <button class="btn-link link-unstyled" id="resources" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                Resources
-                                <i class="fa fa-caret-down" aria-hidden="true"></i></button>
-                                <ul class="dropdown-menu" aria-labelledby="resources">
-                                    <li><a class="link-unstyled" href="https://orcwg.org/events/">Events</a></li>
-                                    <li><a class="link-unstyled" href="https://orcwg.org/resources/calendar/">Community Calendar</a></li>
-                                    <li><a class="link-unstyled" href="https://orcwg.org/blog/">Blog</a></li>
-                                    <li><a class="link-unstyled" href="https://orcwg.org/resources/videos/">Videos</a></li>
-                                    <li><a class="link-unstyled" href="https://orcwg.org/resources/marketing-resources/">Marketing Resources</a></li>
-                                    <li><a class="link-unstyled" href="https://eclipse-foundation.store/collections/open-regulatory-compliance-orc">ORC Store</a></li>
-                                </ul>
-                            </div>
-                        </li>
+                        {% endfor %}
                     </ul>
                 </nav>
                 <div class="header-navbar-end"><a class="header-navbar-end-download-btn btn btn-primary" href="/participate/"><i class="fa" aria-hidden="true"></i>

--- a/src/_includes/header.njk
+++ b/src/_includes/header.njk
@@ -5,7 +5,7 @@
                 <div class="header-navbar-brand"><a class="logo-wrapper" href="/" title="Open Regulatory Compliance Working Group"><img src="https://orcwg.org/images/orc-logo.png" alt="" width="120"></a></div>
                 <nav class="header-navbar-nav">
                     <ul class="header-navbar-nav-links">
-                        {% for nav in site.navigation %} 
+                        {% for nav in site.navigation.main %} 
                         <li class="navbar-nav-links-item">
                         {% if nav.children %}
                             <div class="dropdown">

--- a/src/_includes/header.njk
+++ b/src/_includes/header.njk
@@ -1,0 +1,214 @@
+<header class="header-wrapper header-wrapper" id="header">
+    <div class="header-navbar-wrapper">
+        <div class="container">
+            <div class="header-navbar">
+                <div class="header-navbar-brand"><a class="logo-wrapper" href="/" title="Open Regulatory Compliance Working Group"><img src="https://orcwg.org/images/orc-logo.png" alt="" width="120"></a></div>
+                <nav class="header-navbar-nav">
+                    <ul class="header-navbar-nav-links">
+                        <li class="navbar-nav-links-item">
+                            <div class="dropdown">
+                                <button class="btn-link link-unstyled" id="about" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                About
+                                <i class="fa fa-caret-down" aria-hidden="true"></i></button>
+                                <ul class="dropdown-menu" aria-labelledby="about">
+                                    <li><a class="link-unstyled" href="https://orcwg.org/about/">ORC Working Group</a></li>
+                                    <li><a class="link-unstyled" href="https://orcwg.org/special-interest-groups/cyber-resilience/">Cyber Resilience SIG</a></li>
+                                </ul>
+                            </div>
+                        </li>
+                        <li class="navbar-nav-links-item">
+                            <div class="dropdown">
+                                <button class="btn-link link-unstyled" id="membership" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                Membership
+                                <i class="fa fa-caret-down" aria-hidden="true"></i></button>
+                                <ul class="dropdown-menu" aria-labelledby="membership">
+                                    <li><a class="link-unstyled" href="https://orcwg.org/membership/">Our Members</a></li>
+                                    <li><a class="link-unstyled" href="https://orcwg.org/membership/become-a-member/">Become a Member</a></li>
+                                    <li><a class="link-unstyled" href="https://orcwg.org/about/participation-and-membership-faq/">Participation and Membership FAQ</a></li>
+                                </ul>
+                            </div>
+                        </li>
+                        <li class="navbar-nav-links-item">
+                            <div class="dropdown">
+                                <button class="btn-link link-unstyled" id="cra" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                Cyber Resilience Act
+                                <i class="fa fa-caret-down" aria-hidden="true"></i></button>
+                                <ul class="dropdown-menu" aria-labelledby="cra">
+                                    <li><a class="link-unstyled" href="https://orcwg.org/cra/about">About CRA</a></li>
+                                    <li><a class="link-unstyled" href="/">CRA FAQ</a></li>
+                                    <li><a class="link-unstyled" href="https://orcwg.org/cra/resources">CRA Resources</a></li>
+                                    <li><a class="link-unstyled" href="https://github.com/orcwg/cra-hub">CRA Hub on GitHub</a></li>
+                                </ul>
+                            </div>
+                        </li>
+                        <li class="navbar-nav-links-item">
+                            <div class="dropdown">
+                                <button class="btn-link link-unstyled" id="resources" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                Resources
+                                <i class="fa fa-caret-down" aria-hidden="true"></i></button>
+                                <ul class="dropdown-menu" aria-labelledby="resources">
+                                    <li><a class="link-unstyled" href="https://orcwg.org/events/">Events</a></li>
+                                    <li><a class="link-unstyled" href="https://orcwg.org/resources/calendar/">Community Calendar</a></li>
+                                    <li><a class="link-unstyled" href="https://orcwg.org/blog/">Blog</a></li>
+                                    <li><a class="link-unstyled" href="https://orcwg.org/resources/videos/">Videos</a></li>
+                                    <li><a class="link-unstyled" href="https://orcwg.org/resources/marketing-resources/">Marketing Resources</a></li>
+                                    <li><a class="link-unstyled" href="https://eclipse-foundation.store/collections/open-regulatory-compliance-orc">ORC Store</a></li>
+                                </ul>
+                            </div>
+                        </li>
+                    </ul>
+                </nav>
+                <div class="header-navbar-end"><a class="header-navbar-end-download-btn btn btn-primary" href="/participate/"><i class="fa" aria-hidden="true"></i>
+                    Get involved
+                    </a><button class="mobile-menu-btn" aria-label="Toggle mobile navigation menu" aria-expanded="false">
+                    <i class="fa fa-bars fa-xl"></i></button>
+                </div>
+            </div>
+        </div>
+    </div>
+    <nav class="mobile-menu hidden" aria-expanded="false">
+        <ul>
+            <li class="mobile-menu-dropdown">
+                <a class="mobile-menu-item mobile-menu-dropdown-toggle" data-target="about-menu"><span>About</span>
+                <i class="fa fa-chevron-down" aria-hidden="true"></i></a>
+                <div class="mobile-menu-sub-menu-wrapper">
+                    <ul class="mobile-menu-sub-menu mobile-menu-links-menu hidden" id="about-menu">
+                        <li><a class="mobile-menu-item" href="https://orcwg.org/about/">ORC Working Group</a></li>
+                        <li><a class="mobile-menu-item" href="https://orcwg.org/special-interest-groups/cyber-resilience/">Cyber Resilience SIG</a></li>
+                    </ul>
+                </div>
+            </li>
+            <li class="mobile-menu-dropdown">
+                <a class="mobile-menu-item mobile-menu-dropdown-toggle" data-target="membership-menu"><span>Membership</span>
+                <i class="fa fa-chevron-down" aria-hidden="true"></i></a>
+                <div class="mobile-menu-sub-menu-wrapper">
+                    <ul class="mobile-menu-sub-menu mobile-menu-links-menu hidden" id="membership-menu">
+                        <li><a class="mobile-menu-item" href="https://orcwg.org/membership/">Our Members</a></li>
+                        <li><a class="mobile-menu-item" href="https://orcwg.org/membership/become-a-member/">Become a Member</a></li>
+                        <li><a class="mobile-menu-item" href="https://orcwg.org/about/participation-and-membership-faq/">Participation and Membership FAQ</a></li>
+                    </ul>
+                </div>
+            </li>
+            <li class="mobile-menu-dropdown">
+                <a class="mobile-menu-item mobile-menu-dropdown-toggle" data-target="cra-menu"><span>Cyber Resilience Act</span>
+                <i class="fa fa-chevron-down" aria-hidden="true"></i></a>
+                <div class="mobile-menu-sub-menu-wrapper">
+                    <ul class="mobile-menu-sub-menu mobile-menu-links-menu hidden" id="cra-menu">
+                        <li><a class="mobile-menu-item" href="https://orcwg.org/cra/about">About CRA</a></li>
+                        <li><a class="mobile-menu-item" href="/">CRA FAQ</a></li>
+                        <li><a class="mobile-menu-item" href="https://orcwg.org/cra/resources">CRA Resources</a></li>
+                        <li><a class="mobile-menu-item" href="https://github.com/orcwg/cra-hub">CRA Hub on GitHub</a></li>
+                    </ul>
+                </div>
+            </li>
+            <li class="mobile-menu-dropdown">
+                <a class="mobile-menu-item mobile-menu-dropdown-toggle" data-target="resources-menu"><span>Resources</span>
+                <i class="fa fa-chevron-down" aria-hidden="true"></i></a>
+                <div class="mobile-menu-sub-menu-wrapper">
+                    <ul class="mobile-menu-sub-menu mobile-menu-links-menu hidden" id="resources-menu">
+                        <li><a class="mobile-menu-item" href="https://orcwg.org/events/">Events</a></li>
+                        <li><a class="mobile-menu-item" href="https://orcwg.org/resources/calendar/">Community Calendar</a></li>
+                        <li><a class="mobile-menu-item" href="https://orcwg.org/blog/">Blog</a></li>
+                        <li><a class="mobile-menu-item" href="https://orcwg.org/resources/videos/">Videos</a></li>
+                        <li><a class="mobile-menu-item" href="https://orcwg.org/resources/marketing-resources/">Marketing Resources</a></li>
+                        <li><a class="mobile-menu-item" href="https://eclipse-foundation.store/collections/open-regulatory-compliance-orc">ORC Store</a></li>
+                    </ul>
+                </div>
+            </li>
+        </ul>
+    </nav>
+    <div class="eclipsefdn-mega-menu">
+        <div class="mega-menu-submenu container hidden" data-menu-id="about-menu">
+            <div class="mega-menu-submenu-featured-story"></div>
+            <div class="mega-menu-submenu-links-section">
+                <div class="mega-menu-submenu-links">
+                    <p class="menu-heading">ORC Working Group</p>
+                    <ul></ul>
+                </div>
+                <div class="mega-menu-submenu-links">
+                    <p class="menu-heading">Cyber Resilience SIG</p>
+                    <ul></ul>
+                </div>
+            </div>
+            <div class="mega-menu-submenu-ad-wrapper">
+                <div class="eclipsefdn-mega-menu-promo-content mega-menu-promo-content" data-ad-format="ads_square" data-ad-publish-to="eclipse_org_home"></div>
+            </div>
+        </div>
+        <div class="mega-menu-submenu container hidden" data-menu-id="membership-menu">
+            <div class="mega-menu-submenu-featured-story"></div>
+            <div class="mega-menu-submenu-links-section">
+                <div class="mega-menu-submenu-links">
+                    <p class="menu-heading">Our Members</p>
+                    <ul></ul>
+                </div>
+                <div class="mega-menu-submenu-links">
+                    <p class="menu-heading">Become a Member</p>
+                    <ul></ul>
+                </div>
+                <div class="mega-menu-submenu-links">
+                    <p class="menu-heading">Participation and Membership FAQ</p>
+                    <ul></ul>
+                </div>
+            </div>
+            <div class="mega-menu-submenu-ad-wrapper">
+                <div class="eclipsefdn-mega-menu-promo-content mega-menu-promo-content" data-ad-format="ads_square" data-ad-publish-to="eclipse_org_home"></div>
+            </div>
+        </div>
+        <div class="mega-menu-submenu container hidden" data-menu-id="cra-menu">
+            <div class="mega-menu-submenu-featured-story"></div>
+            <div class="mega-menu-submenu-links-section">
+                <div class="mega-menu-submenu-links">
+                    <p class="menu-heading">About CRA</p>
+                    <ul></ul>
+                </div>
+                <div class="mega-menu-submenu-links">
+                    <p class="menu-heading">CRA FAQ</p>
+                    <ul></ul>
+                </div>
+                <div class="mega-menu-submenu-links">
+                    <p class="menu-heading">CRA Resources</p>
+                    <ul></ul>
+                </div>
+                <div class="mega-menu-submenu-links">
+                    <p class="menu-heading">CRA Hub on GitHub</p>
+                    <ul></ul>
+                </div>
+            </div>
+            <div class="mega-menu-submenu-ad-wrapper">
+                <div class="eclipsefdn-mega-menu-promo-content mega-menu-promo-content" data-ad-format="ads_square" data-ad-publish-to="eclipse_org_home"></div>
+            </div>
+        </div>
+        <div class="mega-menu-submenu container hidden" data-menu-id="resources-menu">
+            <div class="mega-menu-submenu-featured-story"></div>
+            <div class="mega-menu-submenu-links-section">
+                <div class="mega-menu-submenu-links">
+                    <p class="menu-heading">Events</p>
+                    <ul></ul>
+                </div>
+                <div class="mega-menu-submenu-links">
+                    <p class="menu-heading">Community Calendar</p>
+                    <ul></ul>
+                </div>
+                <div class="mega-menu-submenu-links">
+                    <p class="menu-heading">Blog</p>
+                    <ul></ul>
+                </div>
+                <div class="mega-menu-submenu-links">
+                    <p class="menu-heading">Videos</p>
+                    <ul></ul>
+                </div>
+                <div class="mega-menu-submenu-links">
+                    <p class="menu-heading">Marketing Resources</p>
+                    <ul></ul>
+                </div>
+                <div class="mega-menu-submenu-links">
+                    <p class="menu-heading">ORC Store</p>
+                    <ul></ul>
+                </div>
+            </div>
+            <div class="mega-menu-submenu-ad-wrapper">
+                <div class="eclipsefdn-mega-menu-promo-content mega-menu-promo-content" data-ad-format="ads_square" data-ad-publish-to="eclipse_org_home"></div>
+            </div>
+        </div>
+    </div>
+</header>

--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -19,15 +19,7 @@
     <!-- /Fathom -->
 </head>
 <body>
-    <header class="site-header">
-        <a href="/"><h1>{{ site.title }}</h1></a>
-        <nav class="site-nav">
-            {% for nav in site.navigation %}
-            <a href="{{ nav.url }}" title="{{ nav.description }}"{% if page.url == nav.url %} aria-current="page"{% endif %}>{{ nav.title }}</a>
-            {% endfor %}
-        </nav>
-        <img src="/assets/images/orcwg_orc.png" alt="Open Regulatory Compliance Working Group Orc mascott">
-    </header>
+    {% include "header.njk" %}
 
     <main>
         {{ content | safe }}
@@ -35,6 +27,7 @@
 
     {% include "footer.njk" %}
 
+    <script src="https://orcwg.org/public/js/main.js?v={{ build.timestamp }}"></script>
     <script src="/assets/js/site.js?v={{ build.timestamp }}"></script>
 </body>
 </html>

--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -659,56 +659,6 @@ a.action-button {
     margin-bottom: 0;
 }
 
-/* Footer */
-footer {
-    background: white;
-    color: var(--text-color);
-    margin-top: 60px;
-    padding: 40px 0 30px 0;
-    border-top: 1px solid var(--border-color);
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    gap: 20px;
-}
-
-footer section h4 {
-    color: var(--secondary-color);
-    font-size: 0.8em;
-    font-weight: 600;
-    margin: 0 0 8px 0;
-    letter-spacing: -0.01em;
-}
-
-footer section p {
-    margin: 0 0 6px 0;
-    line-height: 1.4;
-    color: var(--text-light);
-    font-size: 0.7em;
-}
-
-footer section ul {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-}
-
-footer section li {
-    margin-bottom: 4px;
-    font-size: 0.7em;
-    color: var(--text-light);
-}
-
-footer section a,
-footer section button {
-    color: var(--text-light);
-}
-
-/* Footer link hover: color change only */
-footer section a:hover,
-footer section button:hover {
-    color: var(--link-hover-color);
-}
-
 .footnotes {
     font-size: 0.7em;
     color: var(--text-light);

--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -102,53 +102,50 @@ a:hover {
 }
 
 /* Header Layout */
-.site-header {
-    margin: 20px 0 30px 0;
+.submenu {
+    padding: 2rem 0;
+    background: linear-gradient(90deg, var(--primary-dark), var(--primary-color)); 
+    margin-bottom: 2rem;
+}
+
+.submenu ul {
+    list-style: none;
     display: flex;
-    align-items: flex-end;
-    justify-content: space-between;
-    flex-wrap: wrap;
-    gap: 20px;
-}
-
-.site-header>a {
-    white-space: nowrap;
-}
-
-.site-header>a h1 {
+    flex-direction: column;
+    padding: 0;
     margin: 0;
-}
-
-.site-header>a:hover h1 {
-    color: var(--link-hover-color);
-}
-
-.site-nav {
-    display: flex;
-    gap: 15px;
-    flex-wrap: wrap;
+    justify-content: center;
     align-items: center;
 }
 
-.site-nav a {
-    color: var(--primary-dark);
-    font-weight: 500;
-    padding: 8px 12px;
-    border-radius: 6px;
-    transition: all 0.2s ease;
-    font-size: 0.9em;
+.submenu li {
+    border-bottom: 1px solid rgba(255, 255, 255, 0.3);
+    padding: 0.75rem 0;
+    margin-bottom: 0;
 }
 
-.site-nav a:hover,
-.site-nav a[aria-current="page"] {
-    background: var(--background-light);
-    color: var(--primary-color);
+.submenu a {
+    color: #fff;
 }
 
-.site-header>img {
-    width: 90px;
-    height: auto;
-    align-self: center;
+.submenu li:last-child {
+    border-bottom: none;
+}
+
+@media (min-width: 768px) {
+    .submenu {
+        text-align: center;
+    }
+
+    .submenu ul {
+        gap: 8rem;
+        flex-direction: row;
+    }
+
+    .submenu li {
+        border-bottom: none;
+        padding: 0;
+    }
 }
 
 /* Main Content Area */
@@ -1094,21 +1091,6 @@ aside h3 {
         padding: 20px 15px;
     }
 
-    /* Mobile header layout: Title and Logo on first line, Nav on second line */
-    .site-header {
-        align-items: center;
-    }
-
-    .site-nav {
-        order: 1;
-        flex-basis: 100%;
-    }
-
-    footer {
-        grid-template-columns: repeat(2, 1fr);
-        gap: 30px;
-    }
-
     /* Remove section boxing on mobile to save space */
     .section-card {
         background: transparent;
@@ -1159,12 +1141,6 @@ aside h3 {
 
     .markdown-alert-orc_rec::after {
         right: -100px;
-    }
-}
-
-@media (max-width: 480px) {
-    footer {
-        grid-template-columns: 1fr;
     }
 }
 

--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -55,6 +55,11 @@ main {
     max-width: 900px;
 }
 
+/* Reset orcwg.org's styles */
+a:hover {
+    text-decoration: none;
+}
+
 /* Typography */
 h1 {
     font-size: 2.5em;

--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -42,14 +42,17 @@
 }
 
 body {
-    font-family: 'Roboto', sans-serif;
+    font-family: 'Inter', sans-serif;
     line-height: 1.6;
-    max-width: 900px;
     margin: 0 auto;
-    padding: 40px 20px;
     color: var(--text-color);
     background: #fff;
     font-weight: 400;
+}
+
+main {
+    margin: 0 auto;
+    max-width: 900px;
 }
 
 /* Typography */

--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -4,6 +4,8 @@
    =================================================================== */
 
 /* CSS Custom Properties */
+@import 'https://orcwg.org/public/css/styles.css';
+
 :root {
     /* Brand Colors */
     --primary-color: #1cb1d1;

--- a/src/index.njk
+++ b/src/index.njk
@@ -8,7 +8,7 @@ permalink: "/"
 </section>
 
 <nav class="card-grid half-width">
-  {% for nav in site.navigation %}
+  {% for nav in site.navigation.sub %}
   <a href="{{ nav.url }}" class="card">
     <h2>{{ nav.title }}</h2>
     <p>{{ nav.description }}</p>


### PR DESCRIPTION
Relates to https://gitlab.eclipse.org/eclipsefdn/software-dev/websites/orcwg.org/-/issues/53

This patch integrates the header and footer from orcwg.org. The header uses the site.json data and supports child items, allowing you to add dropdowns in the navigation if needed.

